### PR TITLE
Round up header

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -232,7 +232,7 @@ nav {
 
 .full-header {
   flex-direction: column;
-  // animation: appear 4000ms ease;
+  
 
   .embeded-video {
     width: 100%;
@@ -254,7 +254,6 @@ nav {
   width: 100%;
   display: grid;
   grid-template: 1fr 1fr / repeat(12, 1fr);
-  animation: appear 400ms ease;
 
   nav {
     grid-column: 5 / -1;
@@ -337,11 +336,6 @@ nav {
       border-radius: 50%;
       cursor: pointer; 
   }
-}
-
-@keyframes appear {
-  0% { opacity: 0; }
-  100% { opacity: 1; }
 }
 
 

--- a/client/src/VideoStream.js
+++ b/client/src/VideoStream.js
@@ -90,11 +90,13 @@ function VideoStream(props) {
             </section>
 
             <section className="message-controls-container">
+                {source ?
                     <div className="controls">
                         <button className="playPauseBtn paused" onClick={handlePlayBtn}></button>
                         <img className="audioIcon" src={icon} alt="speaker icon" width="18" onClick={handleAudio} />
                         <input className="volumeControl" type="range" min="0" max="1" step="any" value={volume} onChange={handleVolume} />
                     </div>
+                : null }
                 <div className="message">
                     <span>etikett radio - stream description</span>
                 </div>

--- a/client/src/VideoStream.js
+++ b/client/src/VideoStream.js
@@ -8,12 +8,10 @@ import { withRouter, NavLink } from 'react-router-dom';
 function VideoStream(props) {
 
     useEffect(() => {
-        const video = 'https://www.twitch.tv/austinjohnplays/';
-        const audio = 'http://s9.myradiostream.com:44782/listen.mp3';
-        if (ReactPlayer.canPlay(video)) {
-            setSource(video);
+        if (ReactPlayer.canPlay(videoStream)) {
+            setSource(videoStream);
         } else {
-            setSource(audio);
+            setSource(audioStream);
         }
     }, [])
 
@@ -23,9 +21,11 @@ function VideoStream(props) {
         } else {
             setHeaderSize('full-header');
         }
-        console.log(ReactPlayer.canPlay("https://www.twitch.tv/austinjohnplays/"));
     }, [props.location.pathname])
 
+    // https://www.twitch.tv/austinjohnplays/
+    const videoStream = 'https://www.twitch.tv/austinjohnplays/';
+    const audioStream = 'http://s9.myradiostream.com:44782/listen.mp3';
     const [playing, setPlaying] = useState(true);
     const [volume, setVolume] = useState("0.5");
     const [muted, setMuted] = useState(false);
@@ -79,7 +79,7 @@ function VideoStream(props) {
             <section className="embeded-video">
                 <ReactPlayer 
                     className="ReactPlayer"
-                    url="http://s9.myradiostream.com:44782/listen.mp3"
+                    url={source}
                     playing={playing} 
                     volume={parseFloat(volume)} 
                     muted={muted}
@@ -90,7 +90,7 @@ function VideoStream(props) {
             </section>
 
             <section className="message-controls-container">
-                {source ?
+                {source === audioStream ?
                     <div className="controls">
                         <button className="playPauseBtn paused" onClick={handlePlayBtn}></button>
                         <img className="audioIcon" src={icon} alt="speaker icon" width="18" onClick={handleAudio} />

--- a/client/src/VideoStream.js
+++ b/client/src/VideoStream.js
@@ -1,17 +1,17 @@
 import React, { useState, useEffect, useRef } from 'react';
 import ReactPlayer from 'react-player';
 import './App.scss'
-import audio from './icons/audio.png';
-import mute from './icons/mute.png';
+import audioIcon from './icons/audio.png';
+import muteIcon from './icons/mute.png';
 import { withRouter, NavLink } from 'react-router-dom';
 
 function VideoStream(props) {
 
     useEffect(() => {
-        if (ReactPlayer.canPlay(videoStream)) {
-            setSource(videoStream);
-        } else {
-            setSource(audioStream);
+        // Stream that is only available on sundays (for testing): https://www.twitch.tv/austinjohnplays/
+        const video = 'https://www.twitch.tv/chillhopmusic';
+        if (ReactPlayer.canPlay(video)) {
+            setSource(video);
         }
     }, [])
 
@@ -23,15 +23,12 @@ function VideoStream(props) {
         }
     }, [props.location.pathname])
 
-    // https://www.twitch.tv/austinjohnplays/
-    const videoStream = 'https://www.twitch.tv/austinjohnplays/';
-    const audioStream = 'http://s9.myradiostream.com:44782/listen.mp3';
     const [playing, setPlaying] = useState(true);
     const [volume, setVolume] = useState("0.5");
     const [muted, setMuted] = useState(false);
-    const [icon, setIcon] = useState(audio);
+    const [icon, setIcon] = useState(audioIcon);
     const [headerSize, setHeaderSize] = useState('');
-    const [source, setSource] = useState('');
+    const [source, setSource] = useState('http://s9.myradiostream.com:44782/listen.mp3');
     const videoPlayer = useRef();
 
     const handlePlayBtn = e => {
@@ -45,10 +42,10 @@ function VideoStream(props) {
 
         // Change icon
         if (muted) {
-            setIcon(audio);
+            setIcon(audioIcon);
             setVolume(0.5);
         } else {
-            setIcon(mute);
+            setIcon(muteIcon);
             setVolume(0);
         }        
     }
@@ -57,10 +54,10 @@ function VideoStream(props) {
         setVolume(e.target.value);
         if(parseFloat(volume) < 0.15) {
             setMuted(true);
-            setIcon(mute);
+            setIcon(muteIcon);
         } else {
             setMuted(false);
-            setIcon(audio);
+            setIcon(audioIcon);
         }
     }
 
@@ -90,7 +87,7 @@ function VideoStream(props) {
             </section>
 
             <section className="message-controls-container">
-                {source === audioStream ?
+                {source === 'http://s9.myradiostream.com:44782/listen.mp3' ?
                     <div className="controls">
                         <button className="playPauseBtn paused" onClick={handlePlayBtn}></button>
                         <img className="audioIcon" src={icon} alt="speaker icon" width="18" onClick={handleAudio} />

--- a/client/src/VideoStream.js
+++ b/client/src/VideoStream.js
@@ -8,12 +8,22 @@ import { withRouter, NavLink } from 'react-router-dom';
 function VideoStream(props) {
 
     useEffect(() => {
+        const video = 'https://www.twitch.tv/austinjohnplays/';
+        const audio = 'http://s9.myradiostream.com:44782/listen.mp3';
+        if (ReactPlayer.canPlay(video)) {
+            setSource(video);
+        } else {
+            setSource(audio);
+        }
+    }, [])
+
+    useEffect(() => {
         if (props.location.pathname !== '/') {
             setHeaderSize('small-header');
         } else {
             setHeaderSize('full-header');
         }
-
+        console.log(ReactPlayer.canPlay("https://www.twitch.tv/austinjohnplays/"));
     }, [props.location.pathname])
 
     const [playing, setPlaying] = useState(true);
@@ -21,7 +31,7 @@ function VideoStream(props) {
     const [muted, setMuted] = useState(false);
     const [icon, setIcon] = useState(audio);
     const [headerSize, setHeaderSize] = useState('');
-    const [streamUrl, setStreamUrl] = useState('');
+    const [source, setSource] = useState('');
     const videoPlayer = useRef();
 
     const handlePlayBtn = e => {
@@ -69,7 +79,7 @@ function VideoStream(props) {
             <section className="embeded-video">
                 <ReactPlayer 
                     className="ReactPlayer"
-                    url="https://www.twitch.tv/chillhopmusic"
+                    url="http://s9.myradiostream.com:44782/listen.mp3"
                     playing={playing} 
                     volume={parseFloat(volume)} 
                     muted={muted}
@@ -80,11 +90,11 @@ function VideoStream(props) {
             </section>
 
             <section className="message-controls-container">
-                <div className="controls">
-                    <button className="playPauseBtn paused" onClick={handlePlayBtn}></button>
-                    <img className="audioIcon" src={icon} alt="speaker icon" width="18" onClick={handleAudio} />
-                    <input className="volumeControl" type="range" min="0" max="1" step="any" value={volume} onChange={handleVolume} />
-                </div>
+                    <div className="controls">
+                        <button className="playPauseBtn paused" onClick={handlePlayBtn}></button>
+                        <img className="audioIcon" src={icon} alt="speaker icon" width="18" onClick={handleAudio} />
+                        <input className="volumeControl" type="range" min="0" max="1" step="any" value={volume} onChange={handleVolume} />
+                    </div>
                 <div className="message">
                     <span>etikett radio - stream description</span>
                 </div>


### PR DESCRIPTION
Sup bro?

So now it seems to be working on my side. I made these changes:
If the twitch channel is streaming, then the video is going to be loaded, and the controllers disappear. If the channel is not streaming, then React player will load the audio stream, and the controllers are visible. I think it is wiser to do animation stuff more at the end, because we are also going to have the chat and some visuals for when the streaming is offline, and I still don't know how that's gonna look (regarding the code). 
